### PR TITLE
Debug mode

### DIFF
--- a/extendODEuntilSwitch.m
+++ b/extendODEuntilSwitch.m
@@ -53,7 +53,7 @@ while isempty(switchingIndices)
         if switchingPointRelError > config.switchingPointRelTolWarningThreshold
             switchingPointRelErrorPrinted = true;
             relErrorWarning = 'Relative error of numerically computed switching point exceeds threshold: %.16g > %.16g\n';
-            warning(relErrorWarning, switchingPointRelError, config.switchingPointRelTolWarningThreshold);
+            warning('IFDIFF:switchingPointRelError', relErrorWarning, switchingPointRelError, config.switchingPointRelTolWarningThreshold);
         end
     end
 

--- a/extendODEuntilSwitch.m
+++ b/extendODEuntilSwitch.m
@@ -1,22 +1,24 @@
-function extendODEuntilSwitch(datahandle) 
+function extendODEuntilSwitch(datahandle)
 % Extend ODE until t2 (~the switch) using forced evaluation, i.e. the
-% signature in the rhs is kept unchanged during extension. 
+% signature in the rhs is kept unchanged during extension.
 % INPUT: struct with field SWP_detection and .t2 and .solution_until_t1
-% OUTPUT: field SWP_detection.solution_until_t2 updated 
-% or warning when after the switch no change of signature occured. 
+% OUTPUT: field SWP_detection.solution_until_t2 updated
+% or warning when after the switch no change of signature occured.
 
 % timepoint t1 ~ t_i
 % timepoint t2 ~ t_s
 % timepoint t3 ~ t_iplus1
 
+config = makeConfig();
+
 
 % first extension to t2
-extendODEuntilSwitch_t1_to_t2(datahandle);  
+extendODEuntilSwitch_t1_to_t2(datahandle);
 
 
 % check if Signature from t1 to t2 changed, i.e. if there occured a switch.
 data = datahandle.getData();
-s = getSwitchingIndices(datahandle, 0);  
+s = getSwitchingIndices(datahandle, 0);
 
 
 % some switches may not be determined by exactly one number or by a
@@ -27,40 +29,36 @@ s = getSwitchingIndices(datahandle, 0);
 % abs(u) <= epsilon.
 % Hence the switch will only be determined up to a precision that
 % depends on epsilon.
-i = 0; 
+i = 0;
+stepSize = 16*eps(data.SWP_detection.t2);
 while isempty(s)
-    
     % increase t2
-    data.SWP_detection.t2 = data.SWP_detection.t2 + 10^i*16*eps(data.SWP_detection.t2); 
-    i = i+1; 
+    data.SWP_detection.t2 = data.SWP_detection.t2 + stepSize;
     % integrate until the new t2
-    datahandle.setData(data); 
-    extendODEuntilSwitch_t1_to_t2(datahandle);  
-    
+    datahandle.setData(data);
+    extendODEuntilSwitch_t1_to_t2(datahandle);
+
     data = datahandle.getData();
     s = getSwitchingIndices(datahandle, 0);
-    
 
-    % We stop the increasing if the increase of t2 is too much to not be
-    % jutified by inaccuracies. 
-    % We chose here: stop is t2 is increased by more then 1%. 
-    % Hence display warning if i > 13
-    if i > 13 
-        warning('i>13')
+    % Increase step size by factor 10 each iteration until we reach a reasonable limit.
+    % Tradeoff between accuracy and speed.
+    if i <= config.switchingPointMaxIter
+        stepSize = stepSize * 10;
     end
+    i = i + 1;
 end
 
-% when increasing the point t2 does not lead to a change of signature, display warning
-if i > 1
-    warning(['detected switch at ', num2str(data.SWP_detection.t2, '%32.16f\n'),' specified up '])
+if config.debugMode && i > 0
+    if i >= config.switchingPointMaxIter
+        maxIterWarning = "DEBUG: Maximum number of iterations (%u) reached for step size during switching point detection.";
+        warning(maxIterWarning, config.switchingPointMaxIter);
+    end
+    switchingPointInfo = "DEBUG: Detected switch after i=%d iterations at time point t=%.16f\n";
+    fprintf(switchingPointInfo, i, data.SWP_detection.t2);
 end
 
-if isempty(s)
-    % warning und alte signatur setzen
-    warning('Problem not well-defined, switch cannot be detected') 
-end
-
-% save switchingpoint for output (.SWP_detection will be deleted afterwards) 
+% save switchingpoint for output (.SWP_detection will be deleted afterwards)
 data = datahandle.getData();
 data.SWP_detection.switchingpoints{end + 1} = data.SWP_detection.t2;
 
@@ -71,20 +69,7 @@ data.SWP_detection.switchingpoints{end + 1} = data.SWP_detection.t2;
     deval(data.SWP_detection.solution_until_t2, data.SWP_detection.t2));
 data.SWP_detection.signature.switch_cond{end+1} = switch_cond;
 data.SWP_detection.signature.ctrlif_index{end+1} = ctrlif_index;
-data.SWP_detection.signature.function_index{end+1} = function_index; 
+data.SWP_detection.signature.function_index{end+1} = function_index;
 
 datahandle.setData(data)
 end
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/extendODEuntilSwitch.m
+++ b/extendODEuntilSwitch.m
@@ -1,68 +1,76 @@
 function extendODEuntilSwitch(datahandle)
-% Extend ODE until t2 (~the switch) using forced evaluation, i.e. the
-% signature in the rhs is kept unchanged during extension.
-% INPUT: struct with field SWP_detection and .t2 and .solution_until_t1
-% OUTPUT: field SWP_detection.solution_until_t2 updated
-% or warning when after the switch no change of signature occured.
+%EXTENDODEUNTILSWITCH   Extend ODE solution until switch and set new signature.
+%   EXTENDODEUNTILSWITCH(datahandle)
+%
+%   Extend the ODE solution from the previous time point (t1) until the switching time (t2) using forced branching.
+%   Note that t2 has to be part of the new model (i.e. have a new signature). To achieve this, the numerically
+%   computed switching time (t2), which could still be part of the old model due to inaccuracies,
+%   may be increased by this function.
+%
+%   INPUT
+%   Accepts input via datahandle providing the fields
+%       - SWP_detection.switch_cond_t1/t2 : switch condition before and after the numerically computed switch
+%       - SWP_detection.t2 : numerically computed switching time
+%       - SWP_detection.solution_until_t1 : ODE solution before the switch
+%
+%   OUTPUT
+%   Writes results back to datahandle in the fields
+%       - SWP_detection.t2 : updated switching time (guaranteed to be part of a new model)
+%       - SWP_detection.solution_until_t2 : ODE solution until the updated switching time
+%       - SWP_detection.switchingpoints : new switching time appended
+%       - SWP_detection.signature : new signature appended
 
-% timepoint t1 ~ t_i
-% timepoint t2 ~ t_s
-% timepoint t3 ~ t_iplus1
 
 config = makeConfig();
 
-
-% first extension to t2
+% Check if the numerically computed switching point is part of the new model.
 extendODEuntilSwitch_t1_to_t2(datahandle);
-
-
-% check if Signature from t1 to t2 changed, i.e. if there occured a switch.
 data = datahandle.getData();
-s = getSwitchingIndices(datahandle, 0);
+switchingIndices = getSwitchingIndices(datahandle, 0);
 
-
-% some switches may not be determined by exactly one number or by a
-% number that is just slightly bigger, but are within a range that e.g.
-% depend on precision tolerances within the program.
-% E.g. consider the following example:
-% If one wants to test if u == 0, then this is implemented by
-% abs(u) <= epsilon.
-% Hence the switch will only be determined up to a precision that
-% depends on epsilon.
-i = 0;
-stepSize = 16*eps(data.SWP_detection.t2);
-while isempty(s)
-    % increase t2
-    data.SWP_detection.t2 = data.SWP_detection.t2 + stepSize;
-    % integrate until the new t2
+% The numerically computed switching point may still be part of the old model due to inaccuracies.
+% In that case, slightly increment the switching point and reintegrate with forced branching.
+% Repeat this process until a new signature is detected.
+originalT2 = data.SWP_detection.t2;
+switchingPointRelErrorPrinted = false;
+baseOffset = 16*eps(data.SWP_detection.t2);
+iter = 0;
+while isempty(switchingIndices)
+    % Increase t2 and integrate again starting from t1.
+    % We can not start integrating from the old t2 because this would result in integration over a tiny
+    % interval whose result would vanish due to limited floating point accuracy.
+    data.SWP_detection.t2 = data.SWP_detection.t2 + baseOffset * 10^min(iter, config.switchingPointMaxPower);
     datahandle.setData(data);
     extendODEuntilSwitch_t1_to_t2(datahandle);
 
+    % Check if there is a new signature.
     data = datahandle.getData();
-    s = getSwitchingIndices(datahandle, 0);
+    switchingIndices = getSwitchingIndices(datahandle, 0);
 
-    % Increase step size by factor 10 each iteration until we reach a reasonable limit.
-    % Tradeoff between accuracy and speed.
-    if i <= config.switchingPointMaxIter
-        stepSize = stepSize * 10;
+    % Print warning (once) if relative error of numerically computed switching point exceeds threshold.
+    if ~switchingPointRelErrorPrinted
+        switchingPointRelError = abs((data.SWP_detection.t2 - originalT2) / originalT2);
+        if switchingPointRelError > config.switchingPointRelTolWarningThreshold
+            switchingPointRelErrorPrinted = true;
+            relErrorWarning = 'Relative error of numerically computed switching point exceeds threshold: %.16g > %.16g\n';
+            warning(relErrorWarning, switchingPointRelError, config.switchingPointRelTolWarningThreshold);
+        end
     end
-    i = i + 1;
+
+    iter = iter + 1;
 end
 
-if config.debugMode && i > 0
-    if i >= config.switchingPointMaxIter
-        maxIterWarning = "DEBUG: Maximum number of iterations (%u) reached for step size during switching point detection.";
-        warning(maxIterWarning, config.switchingPointMaxIter);
-    end
-    switchingPointInfo = "DEBUG: Detected switch after i=%d iterations at time point t=%.16f\n";
-    fprintf(switchingPointInfo, i, data.SWP_detection.t2);
+% Log events related to searching for the switch.
+if config.debugMode
+    switchingPointInfo = "DEBUG: Detected switch after %d iterations at time point t=%.16g\n";
+    fprintf(switchingPointInfo, iter, data.SWP_detection.t2);
 end
 
-% save switchingpoint for output (.SWP_detection will be deleted afterwards)
+% Add new switching point to history.
 data = datahandle.getData();
 data.SWP_detection.switchingpoints{end + 1} = data.SWP_detection.t2;
 
-% Get the new signature at t2, without forced branching
+% Get the new signature at t2 and add it to the signature history.
 [switch_cond, ctrlif_index, function_index] = ctrlif_getSignature(...
     datahandle, ...
     data.SWP_detection.t2, ...

--- a/extendODEuntilSwitch.m
+++ b/extendODEuntilSwitch.m
@@ -22,10 +22,10 @@ function extendODEuntilSwitch(datahandle)
 
 
 config = makeConfig();
+data = datahandle.getData();
 
 % Check if the numerically computed switching point is part of the new model.
 extendODEuntilSwitch_t1_to_t2(datahandle);
-data = datahandle.getData();
 switchingIndices = getSwitchingIndices(datahandle, 0);
 
 % The numerically computed switching point may still be part of the old model due to inaccuracies.
@@ -60,6 +60,8 @@ while isempty(switchingIndices)
     iter = iter + 1;
 end
 
+data = datahandle.getData();
+
 % Log events related to searching for the switch.
 if config.debugMode
     switchingPointInfo = "DEBUG: Detected switch after %d iterations at time point t=%.16g\n";
@@ -67,7 +69,6 @@ if config.debugMode
 end
 
 % Add new switching point to history.
-data = datahandle.getData();
 data.SWP_detection.switchingpoints{end + 1} = data.SWP_detection.t2;
 
 % Get the new signature at t2 and add it to the signature history.

--- a/extendODEuntilSwitch.m
+++ b/extendODEuntilSwitch.m
@@ -31,10 +31,21 @@ switchingIndices = getSwitchingIndices(datahandle, 0);
 % The numerically computed switching point may still be part of the old model due to inaccuracies.
 % In that case, slightly increment the switching point and reintegrate with forced branching.
 % Repeat this process until a new signature is detected.
-originalT2 = data.SWP_detection.t2;
+t2FromRootFinding = data.SWP_detection.t2;
 baseOffset = 16*eps(data.SWP_detection.t2);
 iter = 0;
 while isempty(switchingIndices)
+    data = datahandle.getData();
+
+    % Throw error if error of switching point obtained from root finding relative to tspan exceeds threshold.
+    % Note: No risk of division by zero since we need to make at least one integration step to detect a switch.
+    switchingPointError = abs((data.SWP_detection.t2 - t2FromRootFinding) ...
+        / (data.SWP_detection.tspan(end) - data.SWP_detection.tspan(1)));
+    if switchingPointError > config.switchingPointErrorThreshold
+        errorMsg = 'Relative error of numerically computed switching point exceeds threshold: %.16g > %.16g\n';
+        error('IFDIFF:switchingPointErrorThreshold', errorMsg, switchingPointError, config.switchingPointErrorThreshold);
+    end
+
     % Increase t2 and integrate again starting from t1.
     % We can not start integrating from the old t2 because this would result in integration over a tiny
     % interval whose result would vanish due to limited floating point accuracy.
@@ -43,19 +54,7 @@ while isempty(switchingIndices)
     extendODEuntilSwitch_t1_to_t2(datahandle);
 
     % Check if there is a new signature.
-    data = datahandle.getData();
     switchingIndices = getSwitchingIndices(datahandle, 0);
-
-    % Throw error if error of numerically computed switching point relative to integrated interval exceeds threshold.
-    diffT2 = data.SWP_detection.t2 - originalT2;
-    integratedInterval = originalT2 - data.SWP_detection.tspan(1);
-    % Note: integratedInterval cannot be zero since we need to make at least one integration step to detect a switch.
-    % Therefore, the below division is safe.
-    switchingPointError = abs(diffT2 / integratedInterval);
-    if switchingPointError > config.switchingPointErrorThreshold
-        errorMsg = 'Relative error of numerically computed switching point exceeds threshold: %.16g > %.16g\n';
-        error('IFDIFF:switchingPointErrorThreshold', errorMsg, switchingPointError, config.switchingPointErrorThreshold);
-    end
 
     iter = iter + 1;
 end

--- a/makeConfig.m
+++ b/makeConfig.m
@@ -24,8 +24,11 @@ end
 % Flag to set debug mode which may display additional information and warnings among other things.
 config.debugMode = false;
 
-% Maximum number of iterations which will increase step size when determining the switching point.
-config.switchingPointMaxIter = 13;
+% Largest power of ten which is added to the switching time when searching for a new signature.
+config.switchingPointMaxPower = 13;
+
+% Print warning if relative error of numerically computed switching point exceeds threshold.
+config.switchingPointRelTolWarningThreshold = 1e-3;
 
 % Chunk size used for preallocation when updating the signature in a ctrlif to avoid frequent resizing of arrays.
 config.ctrlif_signaturePreallocationChunkSize = 30;

--- a/makeConfig.m
+++ b/makeConfig.m
@@ -21,6 +21,12 @@ end
 % ============================== USER CONFIGURATION ==============================
 % NOTE: These values may be adjusted depending on the problem you're trying to solve.
 
+% Flag to set debug mode which may display additional information and warnings among other things.
+config.debugMode = false;
+
+% Maximum number of iterations which will increase step size when determining the switching point.
+config.switchingPointMaxIter = 13;
+
 % Chunk size used for preallocation when updating the signature in a ctrlif to avoid frequent resizing of arrays.
 config.ctrlif_signaturePreallocationChunkSize = 30;
 

--- a/makeConfig.m
+++ b/makeConfig.m
@@ -27,8 +27,8 @@ config.debugMode = false;
 % Largest power of ten which is added to the switching time when searching for a new signature.
 config.switchingPointMaxPower = 13;
 
-% Print warning if relative error of numerically computed switching point exceeds threshold.
-config.switchingPointRelTolWarningThreshold = 1e-3;
+% Throw error if error of numerically computed switching point exceeds threshold.
+config.switchingPointErrorThreshold = 1e-2;
 
 % Chunk size used for preallocation when updating the signature in a ctrlif to avoid frequent resizing of arrays.
 config.ctrlif_signaturePreallocationChunkSize = 30;


### PR DESCRIPTION
## Summary
Added debug mode, better warning messages and some cleanup in `extendODEuntilSwitch`.

## Changelog
- New debug mode flag in config (false by default). 
    - Primarily intended to be used for controlling verbosity of IFDIFF (e.g. printing messages for debugging which should not concern an end user).
    - Moved the abundance of warning messages produced by `extendODEuntilSwitch` to the debug mode.
- Added a warning message if the relative error of the numerically computed switching point (i.e. obtained via root finding on switching function) and the actual switching point determined by IFDIFF (i.e. obtained by moving the original switching point forward and reintegrating until a new signature is detected) is greater than some threshold (default 1e-3 in config).
- Cleaned up `extendODEuntilSwitch` by adding comments and replacing old unused code.

## Related Issues
Closes #8 