### PR TITLE
Remove system() calls in make_mtreeplus and use own filecopy() function.

### DIFF
--- a/Tools/filecopy.m
+++ b/Tools/filecopy.m
@@ -1,0 +1,210 @@
+function [success, message] = filecopy(source, destination, useRecycler, chunksize)
+% [success, message] = filecopy(source, destination, useRecycler, chunksize)
+%
+% Copies source to destination. Overwrites if destination if it exists.
+% If the path of destination does not exist, it is created.
+%
+% INPUT:      source --> source file
+%        destination --> target
+%        useRecycler --> flag to indicate if existing destination shall be deleted or recycled  [default:  true]
+%          chunksize --> amount of bytes to be copied at once                                   [default: 16384]
+%
+% OUTPUT:    success --> true on success, false on failure
+%            message --> messages in human readable format
+%
+%
+% NOTES:
+%   1) In contrast to Matlab's copyfile(), this filecopy() does not maintain the 
+%      source's permissions but uses the current user's permission for the destination file.
+%   2) Wildcards * and ? are NOT SUPPORTED
+%
+% Andreas Sommer, Jul2025
+% code@andreas-sommer.eu
+%
+
+% output variables
+success = false;     %#ok<NASGU> 
+message = '';
+
+% defaults
+if (nargin < 3), useRecycler =  true; end   % delete or recycle?
+if (nargin < 4), chunksize   = 16384; end   % byte size for transfer
+
+% set useRecycler to appropriate string
+if (useRecycler)
+   recyclestate = 'on'; 
+else 
+   recyclestate = 'off';
+end
+
+% check for wildcards
+if contains(source, '*') || contains(source, '?') || contains(destination, '*') || contains(destination, '?')
+   message = addMessage(message, 'Wildcards not yet supported');
+   success = false;
+   return
+end
+
+% dissect destination; if it is a folder, add the source file name
+[destinationPath, destinationFile, destinationExt] = fileparts(destination);
+destinationFile = strcat(destinationFile, destinationExt);  % concantenate file name and extension
+if isempty(destinationFile)
+   [~, sourceFile, sourceExt] = fileparts(source);
+   sourceFile = strcat(sourceFile, sourceExt);
+   destination = fullfile(destinationPath, sourceFile);
+end
+
+% check existence of source (note: isfile only exists from R2017b on)
+if ~exist(source, 'file')
+   success = false;
+   message = addMessage(message, 'Source file %s does not exist', source);
+   return
+end
+
+% if destination exists, delete it (move it into recycler)
+if exist(destination, 'file')
+   oldrecyclestate = recycle(recyclestate);
+   try
+      delete(destination);
+      if exist(destination, 'file')
+         success = false;
+         message = addMessage(message, 'Could not remove existing destination file %s', destination);
+         return;
+      end
+      if useRecycler
+         message = addMessage(message, 'Moved existing destination file %s to recycle bin', destination);
+      else
+         message = addMessage(message, 'Deleted existing destination file %s', destination);
+      end
+   catch
+      success = false;
+      message = addMessage(message, 'Failed to delete existing destination file %s', destination);
+      recycle(oldrecyclestate); % switch back to previous recycle state
+      return   
+   end
+   recycle(oldrecyclestate); % switch back to previous recycle state
+end
+
+% ensure path to destination exists
+if ~isempty(destinationPath)
+   if ~exist(destinationPath, 'dir')
+      [success, ~] = mkdir(destinationPath);
+      if success
+         message = addMessage(message, 'Created destination directory %s', destinationPath);
+      else
+         message = addMessage(message, 'Cannot create destination path %s', destinationPath);
+         return;
+      end
+   end
+end
+
+
+% Checks done, now do the work
+
+
+% try to open files - the helpers don't throw but deliver fileID -1 on failure
+fIDsource      = openFile(source, 'r');
+fIDdestination = openFile(destination, 'w');
+
+% check opening
+if (fIDsource      < 0), success = false; message = addMessage(message, 'Failed to open source file %s'     , source     ); return; end
+if (fIDdestination < 0), success = false; message = addMessage(message, 'Failed to open destination file %s', destination); return; end
+
+% transfer contents
+[success, totalbytes] = copyContents(fIDsource, fIDdestination, chunksize);
+if ~success
+   message = addMessage(message, 'Error while copying file %s to %s around position %d', source, destination, totalbytes);
+   closeFile(fIDsource);
+   closeFile(fIDdestination);
+   return;
+end
+
+% close files
+[successCloseSrc , messageCloseSrc ] = closeFile(fIDsource);
+[successCloseDest, messageCloseDest] = closeFile(fIDdestination);
+
+% check closing
+if ~successCloseSrc , success = false; message = addMessage(message, sprintf('Error closing source file %s : %s'     , source     , messageCloseSrc )); return; end
+if ~successCloseDest, success = false; message = addMessage(message, sprintf('Error closing destination file %s : %s', destination, messageCloseDest)); return; end
+
+% report success
+success = true;
+message = addMessage(message, 'OK');
+
+
+end % of function
+
+
+
+
+%% HELPERS
+
+function [success, totalbytes] = copyContents(fIDsrc, fIDdest, chunksize)
+   totalbytes = 0;
+   try
+      bytecount = 1;
+      while (bytecount > 0)
+         [data, bytecount] = fread(fIDsrc, chunksize);
+         fwrite(fIDdest, data);
+         totalbytes = totalbytes + bytecount;
+      end
+      success = true;
+   catch
+      success = false;
+   end
+end
+
+
+function msg = addMessage(msg, fmt, varargin)
+   newmsg = sprintf(fmt, varargin{:});
+   if isempty(msg)
+      msg = newmsg;
+   else
+      msg = sprintf('%s | %s', newmsg, msg);
+   end
+end
+
+
+function [fileID, success, message] = openFile(filespec, access);
+   try
+      fileID = fopen(filespec, access);
+   catch ME
+      fileID  = -1;
+      success = false;
+      message = ME.message;
+      return
+   end
+   message = '';
+   success = true;
+end
+
+
+function [ success, message ] = closeFile(fileID)
+   % invalid file id, do nothing
+   if fileID < 3; 
+      success = true;
+      message = 'Invalid fileID';
+      return;
+   end
+   % check if file is still open
+   filename = fopen(fileID);
+   if isempty(filename);
+      success = true;
+      message = 'File not open';
+      return;
+   end  
+   % try to close
+   try
+      status = fclose(fileID);
+   catch ME
+      success = false;
+      message = 'Error while closing file';
+      return
+   end
+   if (status~=0)
+      success = false
+      message = 'Error while closing file'; 
+      return
+   end
+   success = true;
+   message = 'OK';
+end

--- a/make_mtreeplus.m
+++ b/make_mtreeplus.m
@@ -6,7 +6,7 @@ function flag = make_mtreeplus(varargin)
 % OUTPUT:  flag  -->  true if successful
 %                     false on failure
 %
-% Andreas Sommer, 2020
+% Andreas Sommer, 2020, 2025
 % andreas.sommer@iwr.uni-heidelberg.de
 % email@andreas-sommer.eu
 %
@@ -14,6 +14,9 @@ function flag = make_mtreeplus(varargin)
 
 % default flag: failure
 flag = false;
+
+% this file uses filecopy from the Tools directory
+ifdiffToolsDirectory = 'Tools';
 
 % set some helpers/constants
 MTREE_STRING         = 'mtree';
@@ -31,8 +34,7 @@ MTREEPLUS_FOLDERNAME = '@mtreeplus';
 % ensure that the current functions runs in working directory
 [maker_path, maker_file, ~] = fileparts(mfilename('fullpath'));
 if ~strcmp(maker_path, pwd())
-   disp('Please call %s from inside its home directory %s', maker_file, maker_path)
-   return
+   error('Please call %s from inside its home directory %s', maker_file, maker_path)
 end
 
 
@@ -149,17 +151,42 @@ end
 
 % ========================================================================================
 
-function copyMtreeFiles(source, destination)
+function copyMtreeFiles(sourceDir, destinationDir)
    % copy contents of mtree path to mtreeplus path
-   % we cannot use copyfile as is (tries to) preserve file permissions and ownership,
+   % we cannot use Matlab's copyfile() as is (tries to) preserve file permissions and ownership,
+   % so we use filecopy() from mmtools package
+   curDir = pwd(); % save current directory
+   try 
+      cd(ifdiffToolsDirectory);                      % make filecopy() reachable; we can rely that we are in the ifdiff folder
+      files = dir(fullfile(sourceDir, '**', '*'));   % read all files including subfolders
+      files = files(~[files.isdir]);                 % exclude folders, keep only files
+      for i = 1:length(files)
+         filespec = fullfile(files(i).folder, files(i).name);
+         fprintf('Copying %s to %s ...\n', filespec, destinationDir);
+         [success, msg] = filecopy(filespec, destinationDir, false);  % false: do not put existing files into recycle bin
+         if ~success, error('Error copying file %s :  %s', filespec, msg); end
+      end
+   catch ME
+      cd(curDir);  % undo the directory change
+      warning('An error occured while copying the mtree folder %s to %s', sourceDir, destinationDir);
+      rethrow(ME);
+   end
+   cd(curDir);     % undo the directory change
+end
+
+% ========================================================================================
+
+function copyMtreeFilesBySystem(sourceDir, destinationDir)
+   % copy contents of mtree path to mtreeplus path
+   % we cannot use Matlab's copyfile() as is (tries to) preserve file permissions and ownership,
    % so we invoke system copy commands to own the copies
    fprintf('Copying files...\n')
    if ispc()
-      copy_command = sprintf('xcopy /s "%s\\*.*" "%s"', source, destination);  % WINDOWS
+      copy_command = sprintf('xcopy /s "%s\\*.*" "%s"', sourceDir, destinationDir);  % WINDOWS
    elseif ismac()
-      copy_command = sprintf('cp -R ''%s'' ''%s'''  , source, destination);  % MAC
+      copy_command = sprintf('cp -R ''%s'' ''%s'''  , sourceDir, destinationDir);  % MAC
    elseif isunix()
-      copy_command = sprintf('cp -R ''%s'' ''%s'''  , source, destination);  % LINUX
+      copy_command = sprintf('cp -R ''%s'' ''%s'''  , sourceDir, destinationDir);  % LINUX
    else
       error('Platform not supported.')
    end
@@ -186,34 +213,22 @@ end
 % ========================================================================================
 
 function copyAndPatchMTREEPLUS(fid_src, fid_dest)
-   % choose patch helper depending on matlab version
-   % MATLAB 9.0  R2016a  35
-   % MATLAB 9.1  R2016b  36
-   % MATLAB 9.2  R2017a  37
-   % MATLAB 9.3  R2017b  38
-   % MATLAB 9.4  R2018a  39
-   % MATLAB 9.5  R2018b  40
-   % MATLAB 9.6  R2019a  41
-   % MATLAB 9.7  R2019b  42
-   % MATLAB 9.8  R2020a  43
-   % MATLAB 9.9  R2020b  44
-   % MATLAB 9.10 R2021a  45
-   % MATLAB 9.11 R2021b  --
+   % choose patch helper depending on matlab version (since 2016, all work)
    TESTED = true; UNTESTED = false;
    if     verLessThan('MATLAB', '9.0')
       error('Incompatible Matlab version.');
-   elseif verLessThan('MATLAB', '9.1'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.0  --> 2016a
-   elseif verLessThan('MATLAB', '9.2'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.1  --> 2016b
-   elseif verLessThan('MATLAB', '9.3'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.2  --> 2017a
-   elseif verLessThan('MATLAB', '9.4'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.3  --> 2017b
-   elseif verLessThan('MATLAB', '9.5'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.4  --> 2018a
-   elseif verLessThan('MATLAB', '9.6'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.5  --> 2018b
-   elseif verLessThan('MATLAB', '9.7'),  copyAndPatch__generic(fid_src, fid_dest, TESTED);     % Version 9.6  --> 2019a
-   elseif verLessThan('MATLAB', '9.8'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.7  --> 2019b
-   elseif verLessThan('MATLAB', '9.9'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.8  --> 2020a
-   elseif verLessThan('MATLAB', '9.10'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.9  --> 2020b
-   elseif verLessThan('MATLAB', '9.11'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.10 --> 2021a
-   elseif verLessThan('MATLAB', '9.12'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.11 --> 2021b
+   elseif verLessThan('MATLAB', '9.1'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.0  --> 2016a  35
+   elseif verLessThan('MATLAB', '9.2'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.1  --> 2016b  36
+   elseif verLessThan('MATLAB', '9.3'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.2  --> 2017a  37
+   elseif verLessThan('MATLAB', '9.4'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.3  --> 2017b  38
+   elseif verLessThan('MATLAB', '9.5'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.4  --> 2018a  39
+   elseif verLessThan('MATLAB', '9.6'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.5  --> 2018b  40
+   elseif verLessThan('MATLAB', '9.7'),  copyAndPatch__generic(fid_src, fid_dest, TESTED);     % Version 9.6  --> 2019a  41
+   elseif verLessThan('MATLAB', '9.8'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.7  --> 2019b  42
+   elseif verLessThan('MATLAB', '9.9'),  copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.8  --> 2020a  43
+   elseif verLessThan('MATLAB', '9.10'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.9  --> 2020b  44
+   elseif verLessThan('MATLAB', '9.11'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.10 --> 2021a  45
+   elseif verLessThan('MATLAB', '9.12'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.11 --> 2021b  --
    elseif verLessThan('MATLAB', '9.13'), copyAndPatch__generic(fid_src, fid_dest, TESTED);     % Version 9.12 --> 2022a
    elseif verLessThan('MATLAB', '9.14'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.13 --> 2022b
    elseif verLessThan('MATLAB', '9.15'), copyAndPatch__generic(fid_src, fid_dest, UNTESTED);   % Version 9.14 --> 2023a

--- a/make_mtreeplus.m
+++ b/make_mtreeplus.m
@@ -161,10 +161,16 @@ function copyMtreeFiles(sourceDir, destinationDir)
       cd(ifdiffToolsDirectory);                      % make filecopy() reachable; we can rely that we are in the ifdiff folder
       files = dir(fullfile(sourceDir, '**', '*'));   % read all files including subfolders
       files = files(~[files.isdir]);                 % exclude folders, keep only files
+      lenSourceDir = numel(sourceDir);
       for i = 1:length(files)
          filespec = fullfile(files(i).folder, files(i).name);
-         fprintf('Copying %s to %s ...\n', filespec, destinationDir);
-         [success, msg] = filecopy(filespec, destinationDir, false);  % false: do not put existing files into recycle bin
+         % Get relative path of target in source mtree dir to preserve folder structure (to avoid issues with private functions)
+         % Might include preceding filesep, but doesn't matter due to fullfile call.
+         [destinationRelPath, ~, ~] = fileparts(filespec(lenSourceDir+1:end));
+         % Include trailing filesep, so filecopy recognizes destination as folder.
+         destinationPath = fullfile(destinationDir, destinationRelPath, filesep);
+         fprintf('Copying %s to %s ...\n', filespec, destinationPath);
+         [success, msg] = filecopy(filespec, destinationPath, false);  % false: do not put existing files into recycle bin
          if ~success, error('Error copying file %s :  %s', filespec, msg); end
       end
    catch ME

--- a/make_mtreeplus.m
+++ b/make_mtreeplus.m
@@ -153,7 +153,8 @@ end
 
 function copyMtreeFiles(sourceDir, destinationDir)
    % copy contents of mtree path to mtreeplus path
-   % we cannot use Matlab's copyfile() as is (tries to) preserve file permissions and ownership,
+   % we cannot use Matlab's copyfile() as it
+   % (tries to) preserve file permissions and ownership,
    % so we use filecopy() from mmtools package
    curDir = pwd(); % save current directory
    try 
@@ -178,7 +179,7 @@ end
 
 function copyMtreeFilesBySystem(sourceDir, destinationDir)
    % copy contents of mtree path to mtreeplus path
-   % we cannot use Matlab's copyfile() as is (tries to) preserve file permissions and ownership,
+   % we cannot use Matlab's copyfile() as it (tries to) preserve file permissions and ownership,
    % so we invoke system copy commands to own the copies
    fprintf('Copying files...\n')
    if ispc()


### PR DESCRIPTION
During the ifdiff workshop 2025, one of the Windows machines did not have "xcopy.exe" in the search path, so make_mtreeplus() failed. 
This new version uses the newly added filecopy() function from mmtools to copy all mtree related files
(slow, but independent from the operating system)

Additionally fixes a previous bug:   
make_mtreeplus used disp() with printf-like arguments, if @mtreeplus folder already exists, leading to an error.

