### PR TITLE
Offer to generate mtreeplus in initIFDIFF

### DIFF
--- a/initIFDIFF.m
+++ b/initIFDIFF.m
@@ -2,30 +2,16 @@ function initIFDIFF()
 %INITIFDIFF
 %
 %Wrapper for the actual initIFDIFF function, so that it can be called from the project root,
-%i.e. without first navigating to the toolbox subfolder.
+%i.e. without first navigating to the toolbox subdirectory.
 
-oldPwd = pwd();
-clPwd = onCleanup(@() cd(oldPwd));
-
+dirOld = pwd();
+restoreDir = onCleanup(@() cd(dirOld));
+% Change to toolbox directory.
 [dirRoot, ~, ~] = fileparts(mfilename('fullpath'));
-% Make sure root directory is not in the path yet, so we call the initIFDIFF function in toolbox subfolder.
-callWithoutWarning(@() rmpath(dirRoot), 'MATLAB:rmpath:DirNotFound');
-% Change to toolbox subfolder.
 dirToolbox = fullfile(dirRoot, 'toolbox');
 cd(dirToolbox);
-
-% Warning: This does not/should not call this function.
-% Instead the actual initIFDIFF function in the toolbox subfolder will be called.
+% Note: This does not/should not call this function.
+% Instead the actual initIFDIFF function in the toolbox subdirectory will be called,
+% since functions in working directory have precedence over functions on MATLAB path.
 initIFDIFF();
-end
-
-function callWithoutWarning(func, warnId)
-w = warning('query', warnId); % Get current state of warning
-warning('off', warnId);
-try
-    func();
-catch ME
-    warning(w.state, warnId); % Restore
-end
-warning(w.state, warnId); % Restore
 end

--- a/toolbox/initIFDIFF.m
+++ b/toolbox/initIFDIFF.m
@@ -17,7 +17,33 @@ function initIFDIFF()
 ifdiffpaths = generateIFDIFFpaths();
 
 % add them to the search path at the beginning (search them first)
-addpath(ifdiffpaths, '-begin'); 
+addpath(ifdiffpaths, '-begin');
 
+% Now that the paths are set, the mtreeplus class should be accessible.
+if ~exist('mtreeplus', 'class')
+    disp('Warning: mtreeplus class required for IFDIFF not found in toolbox directory.')
+    answer = input('Attempt to generate new mtreeplus class? [y/n]: ', 's');
+    if strcmpi(answer, 'y')
+        disp('Running make_mtreeplus script to generate new mtreeplus class.')
+        run_make_mtreeplus();
+    else
+        msg = [
+            'Not generating new mtreeplus class.\n' ...
+            'Make sure to provide an mtreeplus class before using IFDIFF, ' ...
+            'e.g. by running the make_mtreeplus script in the toolbox directory.\n' ...
+            ];
+        fprintf(msg)
+    end
+end
+end
 
-end % of function
+%% Helpers
+% make_mtreeplus script has to be called from the toolbox folder.
+function run_make_mtreeplus()
+dirOld = pwd();
+restoreDir = onCleanup(@() cd(dirOld));
+
+[dirToolbox, ~, ~] = fileparts(mfilename('fullpath'));
+cd(dirToolbox)
+make_mtreeplus;
+end

--- a/toolbox/make_mtreeplus.m
+++ b/toolbox/make_mtreeplus.m
@@ -32,9 +32,11 @@ MTREEPLUS_FOLDERNAME = '@mtreeplus';
 
 
 % ensure that the current functions runs in working directory
-[maker_path, maker_file, ~] = fileparts(mfilename('fullpath'));
+[maker_path, ~, ~] = fileparts(mfilename('fullpath'));
 if ~strcmp(maker_path, pwd())
-   error('Please call %s from inside its home directory %s', maker_file, maker_path)
+    dirOld = pwd();
+    restoreDir = onCleanup(@() cd(dirOld));
+    cd(maker_path);
 end
 
 


### PR DESCRIPTION
# Changes
- Simplified initIFDIFF wrapper by removing unnecessary MATLAB path manipulation.
- Detect whether or not mtreeplus class exists in initIFDIFF. If not, offer user to generate new mtreeplus class by running make_mtreeplus script.
- Allow running make_mtreeplus script from any working directory by switching to the toolbox directory in the make_mtreeplus script and restoring the previous working directory.