### PR TITLE
Preprocess elseif constructs

### DIFF
--- a/tests/TestSolveODE.m
+++ b/tests/TestSolveODE.m
@@ -3,6 +3,15 @@ classdef TestSolveODE < matlab.unittest.TestCase
     %
     %Test special cases for solving ODEs with IFDIFF.
 
+    properties (TestParameter)
+        rhsElseif = { ...
+            @canonicalExampleElseifRHS, ... % Standard reformulation with elseif
+            @canonicalExampleElseifMultipleRHS, ... % Redundant elseif before and after original
+            @canonicalExampleElseifMultipleNestedRHS, ... % Redundant nested elseif
+            @canonicalExampleElseifIgnoreRHS, ... % Ignored elseif
+            @canonicalExampleElseifHelperRHS}; % Elseif in helper functions
+    end
+
     methods (TestClassSetup)
         function setPath(testCase)
             import matlab.unittest.fixtures.PathFixture
@@ -46,6 +55,43 @@ classdef TestSolveODE < matlab.unittest.TestCase
             Gy = arrayfun(@(x) x.Gy, sens);
             % Gy(t) = 1
             testCase.verifyEqual(Gy, ones(size(Gy)), 'AbsTol', atol, 'RelTol', rtol);
+        end
+
+        function testElseif(testCase, rhsElseif)
+            %TESTELSEIF(testCase, rhsElseif)
+            %
+            %Solve canonical example rewritten using elseif syntax.
+            %Compare with analytic solution.
+            %
+            %INPUT:
+            %   rhsElseif - RHS representing canonical example with elseif.
+            %   See test parameter definition in properties for details.
+            %       function_handle
+
+            % Get true solution
+            [solTrue, switchTrue, ~, t0, y0, p] = canonicalExampleAnalyticSolution;
+
+            % Compute solution with IFDIFF
+            % Make sure we integrate a little further than the last switch
+            tFac = 0.1;
+            tf = switchTrue(end) + tFac*(switchTrue(end)-t0);
+            tspan = [t0, tf];
+
+            atol = 1e-13;
+            rtol = 1e-13;
+            opts = odeset('AbsTol', atol, 'RelTol', rtol);
+            datahandle = prepareDatahandleForIntegration(rhsElseif, 'integrator', @ode45, 'options', opts);
+
+            sol = solveODE(datahandle, tspan, y0, p);
+
+            % Check solution
+            tEval = linspace(tspan(1), tspan(end), 1000);
+            yEval = deval(sol, tEval);
+            yTrue = solTrue(tEval);
+            testCase.verifyEqual(yEval, yTrue, 'AbsTol', atol, 'RelTol', rtol);
+
+            % Check switching times
+            testCase.verifyEqual(sol.switches, switchTrue, 'AbsTol', atol, 'RelTol', rtol);
         end
     end
 end

--- a/tests/data/TestSolveODE/canonicalExampleElseifHelper.m
+++ b/tests/data/TestSolveODE/canonicalExampleElseifHelper.m
@@ -1,0 +1,9 @@
+function dx = canonicalExampleElseifHelper(dx,t,x,p)
+if x(1) < p(1)
+    dx(2) = 0;
+elseif x(1) < p(1) + 0.5
+    dx(2) = 5;
+else
+    dx(2) = 0;
+end
+end

--- a/tests/data/TestSolveODE/canonicalExampleElseifHelperRHS.m
+++ b/tests/data/TestSolveODE/canonicalExampleElseifHelperRHS.m
@@ -1,0 +1,5 @@
+function dx = canonicalExampleElseifHelperRHS(t,x,p)
+dx = zeros(2,1);
+dx(1) = 0.01 * t.^2  +  x(2).^3;
+dx = canonicalExampleElseifHelper(dx,t,x,p);
+end

--- a/tests/data/TestSolveODE/canonicalExampleElseifIgnoreRHS.m
+++ b/tests/data/TestSolveODE/canonicalExampleElseifIgnoreRHS.m
@@ -1,0 +1,17 @@
+function dx = canonicalExampleElseifIgnoreRHS(t,x,p)
+dx = zeros(2,1);
+dx(1) = 0.01 * t.^2  +  x(2).^3;
+
+if x(1) < p(1)
+    dx(2) = 0;
+elseif x(1) < p(1) + 0.5
+    dx(2) = 5;
+else
+    dx(2) = 0;
+end
+
+if x(1) < p(1) - 0.3 %ifdiff::ignore
+elseif x(1) < p(1) + 0.5  %ifdiff::ignore
+else
+end
+end

--- a/tests/data/TestSolveODE/canonicalExampleElseifMultipleNestedRHS.m
+++ b/tests/data/TestSolveODE/canonicalExampleElseifMultipleNestedRHS.m
@@ -1,0 +1,62 @@
+function dx = canonicalExampleElseifMultipleNestedRHS(t,x,p)
+dx = zeros(2,1);
+dx(1) = 0.01 * t.^2  +  x(2).^3;
+
+if x(1) < -1
+    dx(1) = inf;
+elseif x(1) < 0
+    dx(1) = inf;
+else
+    dx(1) = dx(1) + 0;
+end
+
+if x(1) < p(1)
+    if x(1) < -1
+        dx(1) = inf;
+        if x(1) < -1
+            dx(1) = inf;
+        elseif x(1) < 0
+            dx(1) = inf;
+        end
+    elseif x(1) < 0
+        dx(1) = inf;
+    else
+        dx(1) = dx(1) + 0;
+    end
+    dx(2) = 0;
+elseif x(1) < p(1) + 0.5
+    dx(2) = 5;
+    if x(1) < -1
+        dx(1) = inf;
+    elseif x(1) < 0
+        dx(1) = inf;
+        if x(1) < -1
+            dx(1) = inf;
+        elseif x(1) < 0
+            dx(1) = inf;
+        end
+    else
+        dx(1) = dx(1) + 0;
+    end
+else
+    if x(1) < -1
+        dx(1) = inf;
+    elseif x(1) < 0
+        dx(1) = inf;
+    else
+        if x(1) < -1
+            dx(1) = inf;
+        elseif x(1) < 0
+            dx(1) = inf;
+        end
+        dx(1) = dx(1) + 0;
+    end
+    dx(2) = 0;
+end
+
+if x(1) < -1
+    dx(1) = inf;
+elseif x(1) < 0
+    dx(1) = inf;
+end
+end

--- a/tests/data/TestSolveODE/canonicalExampleElseifMultipleRHS.m
+++ b/tests/data/TestSolveODE/canonicalExampleElseifMultipleRHS.m
@@ -1,0 +1,26 @@
+function dx = canonicalExampleElseifMultipleRHS(t,x,p)
+dx = zeros(2,1);
+dx(1) = 0.01 * t.^2  +  x(2).^3;
+
+if x(1) < -1
+    dx(1) = inf;
+elseif x(1) < 0
+    dx(1) = inf;
+else
+    dx(1) = dx(1) + 0;
+end
+
+if x(1) < p(1)
+    dx(2) = 0;
+elseif x(1) < p(1) + 0.5
+    dx(2) = 5;
+else
+    dx(2) = 0;
+end
+
+if x(1) < -1
+    dx(1) = inf;
+elseif x(1) < 0
+    dx(1) = inf;
+end
+end

--- a/tests/data/TestSolveODE/canonicalExampleElseifRHS.m
+++ b/tests/data/TestSolveODE/canonicalExampleElseifRHS.m
@@ -1,0 +1,12 @@
+function dx = canonicalExampleElseifRHS(t,x,p)
+dx = zeros(2,1);
+dx(1) = 0.01 * t.^2  +  x(2).^3;
+
+if x(1) < p(1)
+    dx(2) = 0;
+elseif x(1) < p(1) + 0.5
+    dx(2) = 5;
+else
+    dx(2) = 0;
+end
+end

--- a/toolbox/examples/canonicalExample/analyticalSolution.m
+++ b/toolbox/examples/canonicalExample/analyticalSolution.m
@@ -1,26 +1,21 @@
+%% Config
+tf = 20;
+tPlotStep = 0.01;
+
 %% Analytical solution
-yA_1 = @(t) (1/300)*t.^3 + 1;
-yA_2 = 0;
-switching_function_1 = @(t) 5.437 - yA_1(t);
-switch_1 = nthroot(1331.1,3);
+[solTrue, switches, switchingFunctions, t0, y0, p] = canonicalExampleAnalyticSolution;
+tspan = [t0, tf];
+tPlot = t0:tPlotStep:tf;
 
-yB_1 = @(t) 125*( (1/4)*t.^4 + (1/37500)*t.^3 - (switch_1)*t.^3 + (3/2)*(switch_1)^2*t.^2 - 1331.1*t - (1/37500)*1331.1 - (7/4)*(switch_1)^4 + 2662.2*(switch_1)) + 5.437;
-yB_2 = @(t) 5*(t - switch_1);
-switching_function_2 = @(t) 5.437 + 0.5 - yB_1(t);
-switch_2 = fzero(switching_function_2,11);
-
-yC_1 = @(t) (1/300)*t.^3 + yB_2(switch_2)^3*t - (1/300)*switch_2.^3 - yB_2(switch_2)^3*switch_2 + yB_1(switch_2);
-yC_2 = yB_2(switch_2);
 %% Plot second component of the switching function
 t=10.8:0.0001:11.5;
 
-figure(1)
-plot(t,switching_function_1(t),'LineWidth', 3, 'color', 'b')
+figure
+plot(t,switchingFunctions{1}(t),'LineWidth', 3, 'color', 'b')
 hold on
-plot(t,switching_function_2(t),'LineWidth', 3, 'color', 'r')
+plot(t,switchingFunctions{2}(t),'LineWidth', 3, 'color', 'r')
 plot(t,zeros(size(t)), 'k')
-xline(switch_1, 'LineWidth', 2);
-xline(switch_2, 'LineWidth', 2);
+xline(switches, 'LineWidth', 2);
 hold off
 legend('\sigma_1(t)', '\sigma_2(t)')
 xlabel('t')
@@ -32,31 +27,16 @@ set(gca, 'Box', 'off');
 integrator = @ode45;
 odeoptionsrhs_test = odeset( 'AbsTol', 1e-14,'RelTol', 1e-12);
 datahandle    = prepareDatahandleForIntegration('canonicalExampleRHS', 'integrator', func2str(integrator), 'options', odeoptionsrhs_test);
-
-tspan         = [0 20];
-initialvalues = [1;0];
-parameters    = 5.437;
-sol           = solveODE(datahandle, tspan, initialvalues, parameters); 
+sol           = solveODE(datahandle, tspan, y0, p);
 
 %% Plot analytical solution vs. ifdiff
-
-t1 = 0:0.01:switch_1;
-t2 = switch_1:0.01:switch_2;
-t3 = switch_2:0.01:20;
-
-figure(2)
-plot(t1,yA_1(t1), 'color', 'b','LineWidth', 3)
+figure
 hold on
-plot(sol.x(1:18),sol.y(1,1:18), 'o', 'color', 'r', 'MarkerSize', 8,'LineWidth', 1.5) 
-plot(t2,yB_1(t2), 'color', 'b','LineWidth', 3)
-plot(t3,yC_1(t3), 'color', 'b','LineWidth', 3)
-plot(t1,zeros(size(t1)), 'color', 'b','LineWidth', 3)
-plot(t2,yB_2(t2), 'color', 'b','LineWidth', 3)
-plot(t3,yC_2*ones(size(t3)), 'color', 'b','LineWidth', 3)
-plot(sol.x(19:end),sol.y(1,19:end), 'o', 'color', 'r', 'MarkerSize', 8,'LineWidth', 1.5) 
-plot(sol.x,sol.y(2,:), 'o', 'color', 'r','MarkerSize', 8,'LineWidth', 1.5) 
+h1 = plot(tPlot, solTrue(tPlot), 'color', 'b', 'LineWidth', 3, 'DisplayName', 'Analytical solution');
+h2 = plot(sol.x,sol.y, 'o', 'color', 'r', 'MarkerSize', 8,'LineWidth', 1.5, 'DisplayName', 'Solution with Ifdiff');
 hold off
-legend('Analytical solution', 'Solution with Ifdiff')
+
+legend([h1(1), h2(1)]);
 xlabel('time [t]')
 ylabel('solution [y]')
 set(gca, 'FontSize', 24);
@@ -64,35 +44,20 @@ set(gca, 'Box', 'off');
 %set(gca,'XTick',0:5:20);
 
 %% Plot analytical solution vs ode45
-tspan         = [0 20];
-initialvalues = [1;0];
-parameters    = 5.437;
-canonicalExampleRHS_ode45 = @(t,y) canonicalExampleRHS(t,y,parameters);
-sol_ode45 = ode45(canonicalExampleRHS_ode45, tspan, initialvalues);
+canonicalExampleRHS_ode45 = @(t,y) canonicalExampleRHS(t,y,p);
+sol_ode45 = ode45(canonicalExampleRHS_ode45, tspan, y0);
 
-t1 = 0:0.01:switch_1;
-t2 = switch_1:0.01:switch_2;
-t3 = switch_2:0.01:20;
-
-figure(3)
+figure
 %axis([0 20 0 20])
-plot(t1,yA_1(t1), 'color', 'b','LineWidth', 3)
 hold on
-plot(sol_ode45.x(1:6),sol_ode45.y(1,1:6), '--', 'LineWidth', 3,'color', 'r', 'MarkerSize', 8)
-plot(sol_ode45.x, 0, 'ko','lineWidth', 3, 'MarkerSize', 8);
-plot(t2,yB_1(t2), 'color', 'b','LineWidth', 3)
-plot(t3,yC_1(t3), 'color', 'b','LineWidth', 3)
-plot(t1,zeros(size(t1)), 'color', 'b','LineWidth', 3)
-plot(t2,yB_2(t2), 'color', 'b','LineWidth', 3)
-plot(t3,yC_2*ones(size(t3)), 'color', 'b','LineWidth', 3)
-plot(sol_ode45.x(6:end),sol_ode45.y(1,6:end), '--', 'LineWidth', 3,'color', 'r', 'MarkerSize', 8)
-plot(sol_ode45.x,sol_ode45.y(2,:), '--','LineWidth', 3, 'color', 'r', 'MarkerSize', 8) 
-xline(switch_1, ':', 'LineWidth', 3);
-xline(switch_2, ':', 'LineWidth', 3);
-plot(sol_ode45.x, 0, 'ko','lineWidth', 3, 'MarkerSize', 8);
+h1 = plot(tPlot, solTrue(tPlot), 'color', 'b', 'LineWidth', 3, 'DisplayName', 'Analytical solution');
+h2 = plot(sol_ode45.x,sol_ode45.y, '--', 'LineWidth', 3, 'color', 'r', 'MarkerSize', 8, 'DisplayName', 'Solution with ode45');
+h3 = plot(sol_ode45.x, 0, 'ko','lineWidth', 3, 'MarkerSize', 8, 'DisplayName', 'Integrator steps');
+xline(switches, ':', 'LineWidth', 3);
 hold off
-legend('Analytical solution', 'Solution with ode45', 'Integrator steps')
-%set(gca,'XTick',0:2:20); 
+
+legend([h1(1), h2(1), h3(1)]);
+%set(gca,'XTick',0:2:20);
 %set(gca,'YTick',[1 5 10 15 20 25 30]);
 xlabel('time [t]')
 ylabel('solution [y]')
@@ -100,25 +65,13 @@ set(gca, 'FontSize', 24);
 set(gca, 'Box', 'off');
 
 %% Plot part of analytical solution for presentation
-
-t1 = 0:0.01:switch_1;
-t2 = switch_1:0.01:switch_2;
-t3 = switch_2:0.01:20;
-
-figure(4)
+figure
 axis([0 16 0 20])
-plot(t1,yA_1(t1), 'color', 'b','LineWidth', 3)
 hold on
-axis([0 16 0 20])
-plot(t2,yB_1(t2), 'color', 'b','LineWidth', 3)
-plot(t3,yC_1(t3), 'color', 'b','LineWidth', 3)
-plot(t1,zeros(size(t1)), 'color', 'b','LineWidth', 3)
-plot(t2,yB_2(t2), 'color', 'b','LineWidth', 3)
-plot(t3,yC_2*ones(size(t3)), 'color', 'b','LineWidth', 3)
-xline(switch_1, ':', 'LineWidth', 3);
-xline(switch_2, ':', 'LineWidth', 3);
+h1 = plot(tPlot, solTrue(tPlot), 'color', 'b', 'LineWidth', 3, 'DisplayName', 'Analytical solution');
+xline(switches, ':', 'LineWidth', 3);
 hold off
-legend('Analytical solution')
+legend(h1(1));
 xlabel('time [t]')
 ylabel('solution [y]')
 set(gca, 'FontSize', 18);

--- a/toolbox/examples/canonicalExample/canonicalExampleAnalyticSolution.m
+++ b/toolbox/examples/canonicalExample/canonicalExampleAnalyticSolution.m
@@ -1,0 +1,158 @@
+function [funcSolPiecewise, tSwitch, switchingFunc, varargout] = canonicalExampleAnalyticSolution()
+%[funcSolPiecewise, tSwitch, switchingFunc, varargout] = CANONICALEXAMPLEANALYTICSOLUTION()
+%[funcSolPiecewise, tSwitch, switchingFunc, t0, y0, p] = CANONICALEXAMPLEANALYTICSOLUTION()
+%
+%Return the analytic solution including switching times and functions for the canonical example.
+%
+%OUTPUT:
+%   funcSolPiecewise - Function that takes time points t (1xn double)
+%   and outputs solution y (2xn double) at the given points
+%       function_handle
+%
+%   tSwitch - Switching times
+%       1x2 double
+%
+%   switchingFunc - Switching functions
+%       1x2 cell of function_handle
+%
+%   t0, y0, p (optional) - Initial conditions and parameters (currently hardcoded)
+%       double, 2x1 double, double
+
+% ============Derivation===============
+% RHS:
+% f_1(t,y,p) = 0.01*t^2 + y_2^3
+% f_2(t,y,p) = 0 if y_1 < p
+%            = 5 if p <= y_1 < p + 0.5
+%            = 0 if y_1 >= p + 0.5
+% =====================================
+% Submodel 1:
+% Assuming initial conditions y(0) = [1; 0] and p > 1, i.e. y_2 = 0 and y_1 < p
+% f^1_1(t,y,p) = 0.01*t^2
+% f^1_2(t,y,p) = 0
+%
+% Solution given by:
+% y^1_1(t) = (1/3)*0.01*t^3 + 1
+% y^1_2(t) = 0
+%
+% First switch t_1 when y^1_1(t_1) = p
+% t_1 = root3[((1/3)*0.01)^(-1) * (p-1)]
+% =====================================
+% Submodel 2:
+% RHS is now:
+% f^2_1(t,y,p) = 0.01*t^2 + y_2(t)^3
+% f^2_2(t,y,p) = 5
+%
+% Solution:
+% y^2_2(t) = 5*(t-t_1)
+% Plug into RHS: f^2_1(t,y,p) = 0.01*t^2 + 125*(t-t_1)^3
+% Integrate:
+% int(0.01*t^2) = (1/3)*0.01+t^3 + C = y_1^1(t) - 1 + C
+% int(125*(t-t_1)^3) = 125/4*(t-t_1)^4 + C
+% y^2_1(t) = 125/4*(t-t_1)^4 + y^1_1(t) - 1 + C
+% Since y^2_1(t_1) = y^1_1(t_1) it follows C = 1, i.e.
+% y^2_1(t) = 125/4*(t-t_1)^4 + y^1_1(t)
+%
+% Second switch t_2 when y^2_1(t_2) = p + 0.5
+% Determining t_2 involves solving a quartic.
+% In practice numerical solution should be used (well-suited here since y^2_1(t) is increasing for t>=t_1>=0)
+% =====================================
+% Submodel 3:
+% RHS is now:
+% f^3_1(t,y,p) = 0.01*t^2 + y_2(t)^3 = 0.01*t^2 + y^2_2(t_2)^3
+% f^3_2(t,y,p) = 0
+%
+% Solution given by:
+% y^3_1(t) = (1/3)*0.01*t^3 + y^2_2(t_2)^3*t + C = y^1_1(t) + y^2_2(t_2)^3*t - 1 + C
+% y^3_2(t) = y^2_2(t_2)
+%
+% Determine integration constant via condition y^3_1(t_2) = y^2_1(t_2):
+% y^2_1(t_2) = y^1_1(t_2) + 125/4*(t_2-t_1)^4 = y^1_1(t_2) + 1/20*y^2_2(t_2)^4
+% y^3_1(t_2) = y^1_1(t_2) + y^2_2(t_2)^3*t_2 - 1 + C
+% Simplify and rearrange equation:
+% C = 1 + y^2_2(t_2)^3*(1/20*y^2_2(t_2) - t_2)
+
+% TODO: Make it possible to specify initial conditions and parameters.
+% For now hardcoded to simplify computations.
+t0 = 0;
+y0 = [1; 0];
+p = 5.437;
+if nargout > 3
+    varargout{1} = t0;
+end
+if nargout > 4
+    varargout{2} = y0;
+end
+if nargout > 5
+    varargout{3} = p;
+end
+
+
+% RHS:
+% f_1(t,y,p) = tFac*t^tExp + y_2^yExp
+% f_2(t,y,p) = 0 if y_1 < p
+%            = dy2 if p <= y_1 < p + pDelta
+%            = 0 if y_1 >= p + pDelta
+pDelta = 0.5;
+tFac = 0.01;
+tExp = 2;
+yExp = 3;
+dy2 = 5;
+
+y = cell(2,3);
+tSwitch = zeros(1,2);
+switchingFunc = cell(size(tSwitch));
+% Submodel 1
+y{1,1} = @(t) y0(1) + (tFac/(tExp+1)) .* t.^(tExp+1);
+y{2,1} = @(t) y0(2) + zeros(size(t));
+switchingFunc{1} = @(t) p - y{1,1}(t);
+tSwitch(1) = nthroot((tExp+1)/tFac * (p-y0(1)), tExp+1);
+% Submodel 2
+y{1,2} = @(t) y{1,1}(t) + (dy2^3/(yExp+1)) .* (t-tSwitch(1)).^(yExp+1);
+y{2,2} = @(t) dy2 .* (t-tSwitch(1));
+switchingFunc{2} = @(t) (p+pDelta) - y{1,2}(t);
+tSwitch(2) = fzero(switchingFunc{2}, tSwitch(1));
+y22Switch = y{2,2}(tSwitch(2));
+% Submodel 3
+IC = (y22Switch^yExp) * (y22Switch/(dy2*(yExp+1)) - tSwitch(2));
+y{1,3} = @(t) IC + y{1,1}(t) + y22Switch^yExp.*t;
+y{2,3} = @(t) y22Switch + zeros(size(t));
+
+% Return full column vectors for each submodel.
+yFull = cell(1,3);
+for idxModel=1:size(y, 2)
+    yFull{idxModel} = @(t) [y{1, idxModel}(t); y{2, idxModel}(t)];
+end
+
+funcSolPiecewise = @(t) evalPiecewise(t, yFull, length(y0), tSwitch);
+end
+
+function y = evalPiecewise(t, solPiece, dimy, sw)
+% Make sure eval points and switching times are sorted in ascending order.
+[t, tSortIdx] = sort(t);
+sw = sort(sw);
+y = zeros(dimy, length(t));
+
+done = false;
+idxModelStart = 1;
+for idxSw=1:length(sw)
+    % Since eval points and switching times are sorted, we look for the first eval point that lies after the next switch.
+    idxModelEnd = (idxModelStart - 1) + find(t(idxModelStart:end) >= sw(idxSw), 1);
+    % If no such point exists, then we stay in the same model until the end.
+    if isempty(idxModelEnd)
+        y(:, idxModelStart:end) = solPiece{idxSw}(t(idxModelStart:end));
+        done = true;
+        break
+    end
+    % Otherwise, evaluate points before switch in the current model and update model for next iteration.
+    y(:, idxModelStart:idxModelEnd-1) = solPiece{idxSw}(t(idxModelStart:idxModelEnd-1));
+    idxModelStart = idxModelEnd;
+end
+
+% If we actually reach the last model or stay in first model, then we have to evaluate the remaining points in that model.
+if ~done
+    y(:, idxModelStart:end) = solPiece{end}(t(idxModelStart:end));
+end
+
+% Reverse the sorting
+y(:, tSortIdx) = y(:, 1:end);
+end

--- a/toolbox/internal/mtreeUtils/mtree_getIgnoredIfs.m
+++ b/toolbox/internal/mtreeUtils/mtree_getIgnoredIfs.m
@@ -20,7 +20,13 @@ function nodeIndices = mtree_getIgnoredIfs(mtreeobj)
             % search in the if body and every elseif/else body for more if nodes and add these to the list
             bodyIndex = mtreeobj.T(ifIndex, cIndex.indexLeftchild);
             while bodyIndex ~= 0
-                bodySubtree = Tree(select(mtreeobj, mtreeobj.T(bodyIndex, cIndex.indexRightchild)));
+                bodyContentStartIndex = mtreeobj.T(bodyIndex, cIndex.indexRightchild);
+                % Body of if/else may be empty
+                if bodyContentStartIndex == 0
+                    bodyIndex = mtreeobj.T(bodyIndex, cIndex.indexNextNode);
+                    continue
+                end
+                bodySubtree = Tree(select(mtreeobj, bodyContentStartIndex));
                 subtreeRIndex = mtree_rIndex(bodySubtree);
 
                 ifs  = getOrDefault(subtreeRIndex.BODY, 'IF', []);

--- a/toolbox/internal/mtreeUtils/mtree_replaceElseif.m
+++ b/toolbox/internal/mtreeUtils/mtree_replaceElseif.m
@@ -1,0 +1,44 @@
+function mtree = mtree_replaceElseif(mtree)
+%mtree = MTREE_REPLACEELSEIF(mtree)
+%
+%Replace all elseif blocks with semantically equivalent else-if blocks.
+%
+%INPUT:
+%   mtree - Mtree containing the elseif blocks.
+%       mtreeplus
+%
+%OUTPUT:
+%   mtree - Modified mtree with all elseif blocks replaced by else-if blocks.
+%       mtreeplus
+
+% Get all ELSEIF nodes.
+nodeElseifFull = mtree.mtfind('Kind', 'ELSEIF');
+if nodeElseifFull.m == 0
+    % No elseif in code.
+    return
+end
+
+cIndex = mtree_cIndex;
+% Handle each ELSEIF node separately, since multiple can be attached to one if.
+for idxElseif=nodeElseifFull.indices
+    nodeElseif = nodeElseifFull.select(idxElseif);
+    % Get IFHEAD node of ELSEIF node.
+    nodeIfhead = nodeElseif.Parent;
+
+    % Add ELSE node to IFHEAD via Next.
+    [mtree, nodeElseIdx] = mtree_createAndAdd_NewNode( ...
+        mtree, ...
+        nodeIfhead.indices, cIndex.indexNextNode, ...
+        mtree.K.ELSE);
+
+    % Add IF node as Body of ELSE node (right child). Connect IF node to ELSEIF node via Arg (left child).
+    mtree = mtree_createAndAdd_NewNode( ...
+        mtree, ...
+        nodeElseIdx, cIndex.indexRightchild, ...
+        mtree.K.IF, ...
+        nodeElseif.indices, cIndex.indexLeftchild);
+
+    % Change ELSEIF node to IFHEAD node. (same structure so only change node type)
+    mtree.T(nodeElseif.indices, cIndex.kindOfNode) = mtree.K.IFHEAD;
+end
+end

--- a/toolbox/internal/rhsPreprocessing/preprocess.m
+++ b/toolbox/internal/rhsPreprocessing/preprocess.m
@@ -15,6 +15,9 @@ preprocessed.rhs = cell(4,1);
 preprocessed.rhs{1,1} = filename;
 preprocessed.rhs{2,1} = [config.preprocessedRhsNamePrefix, filename];
 preprocessed.rhs{3,1} = mtreeplus(strcat(filename, '.m'), '-file', '-comments');
+% Before we do any mtree analysis or modifications, replace all elseif blocks by else-if blocks.
+% Note: This operation preserves if/elseif ignore comments.
+preprocessed.rhs{3,1} = mtree_replaceElseif(preprocessed.rhs{3,1});
 preprocessed.rhs{4,1} = [mtree_getIgnoredIfs(preprocessed.rhs{3,1}) mtree_getJumpUpdateIgnores(preprocessed.rhs{3,1})];
 
 % get all paths that are required to execute filename.m (we want to

--- a/toolbox/internal/rhsPreprocessing/preprocess_fcnInRhs.m
+++ b/toolbox/internal/rhsPreprocessing/preprocess_fcnInRhs.m
@@ -19,7 +19,8 @@ occursUnignored              = zeros(1, l);
 for i = 1:l
     
     mtree_fcn = mtreeplus([preprocessed.fcn{1,i}, '.m'], '-file', '-comments');
-
+    % First, replace elseif by else-if
+    mtree_fcn = mtree_replaceElseif(mtree_fcn);
     fcn{4,i} = [mtree_getIgnoredIfs(mtree_fcn), mtree_getJumpUpdateIgnores(mtree_fcn)];
     [mtree_fcn, ctrlif_new] = preprocess_addCtrlif(mtree_fcn, preprocessed.ctrlif_index, fcn{4,i});
 


### PR DESCRIPTION
# Summary
- IFDIFF can now properly handle the `elseif` keyword being used in a RHS by transforming `elseif` blocks into semantically equivalent `if-else` blocks.
- The `elseif` keyword appearing in a helper function is also handled.
- An `elseif` block can still be ignored just like any other `if` block.
- Appropriate tests for the new functionality were added.
# Related Issues
- Closes #53