### PR TITLE
Add detailed installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A compact, self-explanatory MATLAB example is provided in this file. ([`Readme_E
 
 ## Installation
 
-There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF without any local installation in the cloud-based "MATLAB Online" environment. In that case, simply press the "Open in MATLAB Online" button below to import the IFDIFF repository in MATLAB Online.
+There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF without any local installation in the cloud-based "MATLAB Online" environment. In that case, press the "Open in MATLAB Online" button below to import the IFDIFF repository in MATLAB Online.
 
 [![Open in MATLAB Online](https://www.mathworks.com/images/responsive/global/open-in-matlab-online.svg)](https://matlab.mathworks.com/open/github/v1?repo=andreassommer/ifdiff&file=toolbox/doc/GettingStarted.mlx)
 
@@ -75,7 +75,7 @@ You can also open the guide manually:
 
 For a step-by-step usage example and background explanation, see the [IFDIFF  project page](https://andreassommer.github.io/ifdiff/).
 
-Afterwards, you can check out our Getting Started Guide in MATLAB for a hands-on walkthrough on how to use IFDIFF. If you have trouble finding the Getting Started Guide, please refer to the last step of the [installation section](#installation) for [toolbox installations](#install-toolbox-recommended) or [full repository installations](#install-full-repository-alternative) (whichever applies in your case).
+Afterwards, you can check out the Getting Started Guide in MATLAB for a hands-on walkthrough on how to use IFDIFF. If you have trouble finding the Getting Started Guide, please refer to the last step of the [installation section](#installation) for [toolbox installations](#install-toolbox-recommended) or [full repository installations](#install-full-repository-alternative) (whichever applies in your case).
 
 ### Prerequisites
 
@@ -91,7 +91,7 @@ After running the command, you will receive a prompt in the Command Window askin
 
 #### On Each MATLAB Session (required only for non-toolbox installations)
 
-If you have not installed IFDIFF as a toolbox, then you must manually setup the MATLAB path to access IFDIFF functions on each MATLAB session before you can use IFDIFF. To do this, simply run the following command in the MATLAB Command Window:
+If you have not installed IFDIFF as a toolbox, then you must manually setup the MATLAB path to access IFDIFF functions on each MATLAB session before you can use IFDIFF. To do this, run the following command in the MATLAB Command Window:
 
 ```MATLAB
 initIFDIFF

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Workshop: Thursday, July 09, 2026
+
 ## Filippov-ODEs and DAEs with State-dependent Switches
 
 **Theory and Hands-On Practical with IFDIFF**
@@ -10,11 +11,12 @@ Im Neuenheimer Feld 205 • 69120 Heidelberg
 
 Participation is free. [Register here!](https://t1p.de/ifdiff2026)
 
-
 # IFDIFF - A MATLAB Toolkit for ODEs with State˗Dependent Switches
+
 [![Open in MATLAB Online](https://www.mathworks.com/images/responsive/global/open-in-matlab-online.svg)](https://matlab.mathworks.com/open/github/v1?repo=andreassommer/ifdiff&file=toolbox/doc/GettingStarted.mlx)
 
 The software package IFDIFF comprises:
+
 - **Automatic detection and processing** of state-dependent switching events in ODE IVPs
 - **Automatic generation** of only the necessary **switching functions** (exported as MATLAB code)
 - Accurate switching point detection up to machine precision
@@ -29,13 +31,13 @@ For a mathematical introduction and illustrative examples, see the
 
 A compact, self-explanatory MATLAB example is provided in this file. ([`Readme_Example.m`](./toolbox/examples/Readme_Example.m))
 
-# Installation
+## Installation
 
-There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF without any local installation in the cloud-based "MATLAB Online" environment. In that case, simply press the "Open in MATLAB Online" button below to import the IFDIFF project in MATLAB Online.
+There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF without any local installation in the cloud-based "MATLAB Online" environment. In that case, simply press the "Open in MATLAB Online" button below to import the IFDIFF repository in MATLAB Online.
 
 [![Open in MATLAB Online](https://www.mathworks.com/images/responsive/global/open-in-matlab-online.svg)](https://matlab.mathworks.com/open/github/v1?repo=andreassommer/ifdiff&file=toolbox/doc/GettingStarted.mlx)
 
-## Install Toolbox (Recommended)
+### Install Toolbox (Recommended)
 
 1. Download the IFDIFF toolbox file (`IFDIFF_Toolbox_vXXX.mltbx`) from the [releases page](https://github.com/andreassommer/ifdiff/releases/latest).
 2. Open MATLAB and navigate to the directory containing the toolbox file.
@@ -51,7 +53,7 @@ There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF 
         matlab.addons.toolbox.installToolbox('IFDIFF_Toolbox_vXXX.mltbx');
         ```
 
-4. For a detailed introduction to IFDIFF, view the Getting Started Guide (`GettingStarted.mlx`). The guide should open automatically after installing the toolbox file from the GUI.  
+4. For a practical introduction to IFDIFF, view the Getting Started Guide (`GettingStarted.mlx`). The guide should open automatically after installing the toolbox file from the GUI.  
 You can also open the guide manually:
     - From the MATLAB Add-On Manager (recommended):
         1. Open the MATLAB Add-On Manager (Home tab > Environment section > Add-Ons > Manage Add-Ons).
@@ -62,20 +64,35 @@ You can also open the guide manually:
         1. Open the toolbox installation folder. See the [MATLAB Documentation on the Default Add-On Installation Folder](https://www.mathworks.com/help/matlab/matlab_env/get-add-ons.html#buy5hl8-1) for detailed instructions on how to find the installation folder.
         2. In the toolbox folder, navigate to the subfolder `doc` and open the file `GettingStarted.mlx` in MATLAB.
 
-## Install Full Repository (Alternative)
+### Install Full Repository (Alternative)
 
 1. Navigate to a location of your choice on your PC (e.g. Desktop).
 2. Clone the repository `git clone https://github.com/andreassommer/ifdiff.git`.
 3. Open MATLAB and navigate to the cloned `ifdiff` directory.
-4. For a detailed introduction to IFDIFF, open the Gettings Started Guide (`GettingStarted.mlx`) in MATLAB. You can find the guide in the subfolder `toolbox/doc` contained in the cloned `ifdiff` directory.
+4. For a practical introduction to IFDIFF, open the Getting Started Guide (`GettingStarted.mlx`) in MATLAB. You can find the guide in the subfolder `toolbox/doc` contained in the cloned `ifdiff` directory.
 
-# Usage
+## Usage
 
-Once every new MATLAB session run
-
- `initIFDIFF();` 
-
-to initialize the required paths. Then IFDIFF is ready to use. 
-
-The first time the command is executed, a copy of MATLAB's internal parser class `mtree` is created on which IFDIFF heavily relies.
 For a step-by-step usage example and background explanation, see the [IFDIFF  project page](https://andreassommer.github.io/ifdiff/).
+
+Afterwards, you can check out our Getting Started Guide in MATLAB for a hands-on walkthrough on how to use IFDIFF. If you have trouble finding the Getting Started Guide, please refer to the last step of the [installation section](#installation) for [toolbox installations](#install-toolbox-recommended) or [full repository installations](#install-full-repository-alternative) (whichever applies in your case).
+
+### Prerequisites
+
+#### One-Time Setup (required for all installation types)
+
+After installing IFDIFF for the first time, you must run the following command in the MATLAB Command Window before you can start using IFDIFF:
+
+```MATLAB
+initIFDIFF
+```
+
+After running the command, you will receive a prompt in the Command Window asking you to let IFDIFF generate the `mtreeplus` class, which is a copy of MATLAB's internal parser class `mtree` on which IFDIFF heavily relies. Enter `y` in the Command Window to proceed and wait for the script to finish running. At the end you should see a message confirming that the `mtreeplus` class was generated successfully.
+
+#### On Each MATLAB Session (required only for non-toolbox installations)
+
+If you have not installed IFDIFF as a toolbox, then you must manually setup the MATLAB path to access IFDIFF functions on each MATLAB session before you can use IFDIFF. To do this, simply run the following command in the MATLAB Command Window:
+
+```MATLAB
+initIFDIFF
+```

--- a/README.md
+++ b/README.md
@@ -29,31 +29,45 @@ For a mathematical introduction and illustrative examples, see the
 
 A compact, self-explanatory MATLAB example is provided in this file. ([`Readme_Example.m`](./toolbox/examples/Readme_Example.m))
 
-
-</br>
-
-
 # Installation
 
-There are two ways to install IFDIFF.
+There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF without any local installation in the cloud-based "MATLAB Online" environment. In that case, simply press the "Open in MATLAB Online" button below to import the IFDIFF project in MATLAB Online.
 
-## Installation Method (Recommended)
+[![Open in MATLAB Online](https://www.mathworks.com/images/responsive/global/open-in-matlab-online.svg)](https://matlab.mathworks.com/open/github/v1?repo=andreassommer/ifdiff&file=toolbox/doc/GettingStarted.mlx)
 
-1. Download the current release file `IFDIFF_Toolbox.mltbx`.
-2. Open MATLAB and navigate to the directory containing the file.
-3. Right-click the file and select **Install**.
-4. For a detailed introduction, open `GettingStarted.mlx`, which is included with the toolbox.
+## Install Toolbox (Recommended)
 
-Note: You can also open the Getting Started guide directly in 
-[MATLAB Online](https://matlab.mathworks.com/open/github/v1?repo=andreassommer/ifdiff&file=toolbox/doc/GettingStarted.mlx) and then continue with the [First Run Prerequisites](#first-run-prerequisites).
+1. Download the IFDIFF toolbox file (`IFDIFF_Toolbox_vXXX.mltbx`) from the [releases page](https://github.com/andreassommer/ifdiff/releases/latest).
+2. Open MATLAB and navigate to the directory containing the toolbox file.
+3. Install the toolbox file:
+    - From the GUI (recommended):
+        - **MATLAB R2025a or newer**: Double click the toolbox file in the MATLAB Files panel.
+        - **MATLAB R2024b or older**: Right-click the toolbox file in the MATLAB Current Folder browser and select **Install**.
 
-## Installation Method (Alternative)
+    - From the command window (alternative):
+        - **MATLAB R2016a or newer**: Run the following command in the MATLAB Command Window (after replacing the placeholder text `'IFDIFF_Toolbox_vXXX.mltbx'` with the actual name of your toolbox file):
+
+        ```MATLAB
+        matlab.addons.toolbox.installToolbox('IFDIFF_Toolbox_vXXX.mltbx');
+        ```
+
+4. For a detailed introduction to IFDIFF, view the Gettings Started Guide (`GettingStarted.mlx`). The guide should open automatically after installing the toolbox file from the GUI.  
+You can also open the guide manually:
+    - From the MATLAB Add-On Manager (recommended):
+        1. Open the MATLAB Add-On Manager (Home tab > Environment section > Add-Ons > Manage Add-Ons).
+        2. Find the "IFDIFF Toolbox" Add-On in the list of installed Add-Ons.
+        3. Open the context menu by right-clicking the "IFDIFF Toolbox" Add-On or clicking on the three dots that appear on the right when hovering over the "IFDIFF Toolbox" Add-On.
+        4. Click on the "View Getting Started Guide" button in the context menu.
+    - From the file browser (alternative):
+        1. Open the toolbox installation folder. See the [MATLAB Documentation on the Default Add-On Installation Folder](https://www.mathworks.com/help/matlab/matlab_env/get-add-ons.html#buy5hl8-1) for detailed instructions on how to find the installation folder.
+        2. In the toolbox folder, navigate to the subfolder `doc` and open the file `GettingStarted.mlx` in MATLAB.
+
+## Install Full Repository (Alternative)
 
 1. Navigate to a location of your choice on your PC (e.g. Desktop).
-2. Clone the repository `git clone https://github.com/andreassommer/ifdiff.git`
+2. Clone the repository `git clone https://github.com/andreassommer/ifdiff.git`.
 3. Open MATLAB and navigate to the cloned `ifdiff` directory.
-
-</br>
+4. For a detailed introduction to IFDIFF, open the Gettings Started Guide (`GettingStarted.mlx`) in MATLAB. You can find the guide in the subfolder `toolbox/doc` contained in the cloned `ifdiff` directory.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There are two ways to install IFDIFF locally. Alternatively, you may use IFDIFF 
         matlab.addons.toolbox.installToolbox('IFDIFF_Toolbox_vXXX.mltbx');
         ```
 
-4. For a detailed introduction to IFDIFF, view the Gettings Started Guide (`GettingStarted.mlx`). The guide should open automatically after installing the toolbox file from the GUI.  
+4. For a detailed introduction to IFDIFF, view the Getting Started Guide (`GettingStarted.mlx`). The guide should open automatically after installing the toolbox file from the GUI.  
 You can also open the guide manually:
     - From the MATLAB Add-On Manager (recommended):
         1. Open the MATLAB Add-On Manager (Home tab > Environment section > Add-Ons > Manage Add-Ons).


### PR DESCRIPTION
# Summary
- Adjusted the installation instructions in the README to account for UI changes made to the installation process for toolboxes in the recent R2025a MATLAB release.
- Added more detailed instructions for finding the Getting Started Guide and setting up IFDIFF for the first time/on each MATLAB session.
- Some minor formatting cleanup in the README